### PR TITLE
Using absolute paths for views/public_folder directories

### DIFF
--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -34,8 +34,8 @@ class GDash
         end
 
         set :static, true
-        set :views, "views"
-        set :public_folder, "public"
+        set :views, File.join(File.expand_path(File.dirname(__FILE__)), "../..", "views")
+        set :public_folder, File.join(File.expand_path(File.dirname(__FILE__)), "../..", "public")
 
         get '/' do
             if @dash_site.list.empty?


### PR DESCRIPTION
Hey,

Awesome dashboard tool!

This references views/public_folder directoires by their absolute paths, which makes it convenient to run "rackup /path/to/gdash/config.ru" without worrying about the current directory.  It should still work with Passenger, but it's convient to run directly with Rack.
