### PR TITLE
Fix for Rack / Passenger install.

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -7,7 +7,7 @@
     <tbody>
         <% @dash_site.dashboards.sort_by{|b| b[:name]}.each do |board| %>
         <tr>
-            <td><a href="<%= [@prefix, "dashboard", board[:link]].join('/') %>"><%= board[:name] %></a></td><td><%= board[:description] %></td>
+            <td><a href="<%= [@prefix, "dashboard", board[:link]].join('/') %>/"><%= board[:name] %></a></td><td><%= board[:description] %></td>
         </tr>
         <% end %>
     </tbody>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -20,7 +20,7 @@
                                 <a href="#" class="dropdown-toggle">Dashboards</a>
                                 <ul class="dropdown-menu">
                                 <% @dash_site.dashboards.sort_by{|b| b[:name]}.each do |board| %>
-                                    <li><a href="<%= @prefix %>/dashboard/<%= board[:link] %>"><%= board[:name] %></a></li>
+                                    <li><a href="<%= @prefix %>/dashboard/<%= board[:link] %>/"><%= board[:name] %></a></li>
                                 <% end %>
                                 </ul>
                             </li>


### PR DESCRIPTION
With a rack application installation on Passenger in my testing, not having the trailing / causes a 404 to be rendered for links.

Added trailing slash to dashboard links. Fixes 404 message from Rack / Passenger
