### PR TITLE
modify the columns on index.erb so that they are a uniform size

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -3,8 +3,8 @@
 <h2> <%= key.capitalize %> </h2>
 <table>
     <thead>
-        <th>Name</th>
-        <th>Description</th>
+        <th width="30%">Name</th>
+        <th width="70%">Description</th>
     </thead>
     <tbody>
         <% @top_level[key].dashboards.sort_by{|b| b[:name]}.each do |board| %>


### PR DESCRIPTION
I noticed on my index page each table was picking a random width for the columns.  This caused the index page to look a little funky.  This patch fixes the 'Name' column at 30% and the 'Description' column at 70%.  I'm no CSS guy so i don't know if there's a better way to do this.
