### PR TITLE
Adding graph attribute for 'smoothing', aka Graphite's movingAverage().

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -218,6 +218,7 @@ class GraphiteGraph
 
         graphite_target = "derivative(#{graphite_target})" if target[:derivative]
         graphite_target = "scale(#{graphite_target},#{target[:scale]})" if target[:scale]
+        graphite_target = "movingAverage(#{graphite_target},#{target[:smoothing]})" if target[:smoothing]
         graphite_target = "drawAsInfinite(#{graphite_target})" if target[:line]
 
         graphite_target = "color(#{graphite_target},\"#{target[:color]}\")" if target[:color]


### PR DESCRIPTION
I use the movingAverage function quite often on graphs, to make them more visually appealing and to increase the visual signal-to-noise ratio.  

Right now, afaik, the graphite_graph.rb class is duplicated in gdash.git and graphite-graph-dsl.git, and this would need to be updated in the wiki as well.  Give a holler and I can update those, if you like.  

Gdash is a great addition to graph!  Thanks!
