### PR TITLE
Allow showing different timeranges on a single page 

### DIFF
--- a/config/gdash.yaml-sample
+++ b/config/gdash.yaml-sample
@@ -10,3 +10,9 @@
   :graph_width: 500
   :graph_height: 250
   :whisper_dir: "/var/lib/carbon/whisper"
+  :intervals:
+    - [ "-1hour", "1 hour" ]
+    - [ "-2hour", "2 hour" ]
+    - [ "-1day", "1 day" ]
+    - [ "-1month", "1 month" ]
+    - [ "-1year", "1 year" ]

--- a/lib/gdash/monkey_patches.rb
+++ b/lib/gdash/monkey_patches.rb
@@ -32,4 +32,6 @@ class Array
     end
 end
 
-
+class GraphiteGraph
+    attr_accessor :properties, :file
+end

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -4,15 +4,16 @@
     <table>
     <% row = 1 %>
     <% @dashboard.graphs.in_groups_of(@graph_columns) do |graphs| %>
-
         <tr>
-        <% graphs.each do |graph| %>
+        <% graphs.each_with_index do |graph,i| %>
             <td>
             <% if graph %>
                 <% if graph[:graphite][:description] %>
-                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>' rel="<%= row == 1 ? 'popover-below' : 'popover-above' %>" title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
+                    <a href='<%= [@prefix, params[:category], @params[:dash], 'details', i].join "/" %>'>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>' rel="<%= row == 1 ? 'popover-below' : 'popover-above' %>" title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>"></a>
                 <% else %>
-                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>'>
+                    <a href='<%= [@prefix, params[:category], @params[:dash], 'details', i].join "/" %>'>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>'></a>
                 <% end %>
             <% end %>
             </td>

--- a/views/detailed_dashboard.erb
+++ b/views/detailed_dashboard.erb
@@ -1,0 +1,44 @@
+<% unless @error %>
+<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<h2><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<div class="row">
+    <table>
+        <% @graphs.each do |graph| %>
+          <% row = 1 %>
+          <tr>
+            <td>
+            <% if graph %>
+                <% if graph[:description] %>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>' rel="<% row == 1 ? 'popover-below' : 'popover-above' %>" title="<%= graph[:title] %>" data-content="<%= graph[:description] %>">
+                <% else %>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>'>
+                <% end %>
+            <% end %>
+            </td>
+	  </tr>
+          <% row += 1 %>
+        <% end %>
+    </table>
+</div>
+<script>
+    $(function () {
+      $("img[rel=popover-above]")
+        .popover({
+          placement: "above", delayIn: 1000
+        })
+        .click(function(e) {
+          e.preventDefault()
+        })
+    })
+
+    $(function () {
+      $("img[rel=popover-below]")
+        .popover({
+          placement: "below", delayIn: 1000
+        })
+        .click(function(e) {
+          e.preventDefault()
+        })
+    })
+</script>
+<% end %>


### PR DESCRIPTION
This can be useful in a dashboard when you want to
see previous trends for a specific metric.

Intervals can be specified in the config file.
