### PR TITLE
ability to diable alias() for wildcard sources

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -291,7 +291,11 @@ class GraphiteGraph
 
         unless target.include?(:subgroup)
           if target[:alias]
-            graphite_target = "alias(#{graphite_target},\"#{target[:alias]}\")"
+            if target[:alias] == "none"
+            	graphite_target = graphite_target
+            else
+            	graphite_target = "alias(#{graphite_target},\"#{target[:alias]}\")"
+             end
           else
             graphite_target = "alias(#{graphite_target},\"#{name.to_s.capitalize}\")"
           end


### PR DESCRIPTION
I implemented this after needing to include targets such as highestMax(_._.count, 10) where the sources ultimately graphed are unknown.

Adding alias=none to such a graph disables the outer alias call and enables the use of substr() as requested here https://github.com/ripienaar/graphite-graph-dsl/issues/7. 
