### PR TITLE
Quick interval period filters and option to set graph dimensions and interval with url or dasboard config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ structure:
 
 or
 
-    http://gdash.example.com/dashboard/email/?from=-8d&to=-7d
-    http://gdash.example.com/dashboard/email/full/2/600/300?from=-8d&to=-7d
+    http://gdash.example.com/dashboard/email/?from=-8d&until=-7d
+    http://gdash.example.com/dashboard/email/full/2/600/300?from=-8d&until=-7d
 
 This will display the _email_ dashboard with a time interval same day last week.
 If you hit */dashboard/email/time/* it will default to the past hour (*-1hour*)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ and additional options:
     * The width of the graphs, 500 by default
     * The height of the graphs, 250 by default
     * Where your whisper files are stored - future use
+    * Optional interval quick filters
 
 Creating Dashboards?
 --------------------
@@ -77,6 +78,39 @@ over at https://github.com/ripienaar/graphite-graph-dsl/wiki
 
 At the moment we do not support the _Related Items_ feature of the DSL.
 
+Custom Time Intervals?
+--------------------
+
+You can reuse your dashboards and adjust the time interval by using the following url
+structure:
+
+    http://gdash.example.com/dashboard/email/time/-8d/-7d
+
+or
+
+    http://gdash.example.com/dashboard/email/?from=-8d&to=-7d
+    http://gdash.example.com/dashboard/email/full/2/600/300?from=-8d&to=-7d
+
+This will display the _email_ dashboard with a time interval same day last week.
+If you hit */dashboard/email/time/* it will default to the past hour (*-1hour*)
+See http://graphite.readthedocs.org/en/1.0/url-api.html#from-until for more info 
+acceptable *from* and *until* values.
+
+Quick interval filters shown in interface are configurable in _gdash.yaml_ options sections. Eg:
+
+	:options:
+      :interval_filters:
+        - :label: Last Hour
+          :from: -1h
+          :to: now
+        - :label: Last Day
+          :from: -1day
+        - :label: Current Week
+          :from: monday
+          :to: now
+
+Quick filter is not shown when *interval_filters* section is missing in configuration file.
+
 Time Intervals Display?
 -----------------------
 
@@ -102,6 +136,7 @@ You can reuse your dashboards for big displays against a wall in your NOC or off
 by using the following url structure:
 
     http://gdash.example.com/dashboard/email/full/4/600/300
+    http://gdash.example.com/dashboard/email/full/4?width=600&height=300
 
 This will display the _email_ dashboard in _4_ columns each graph with a width of
 _600_ and a height of _300_

--- a/config/gdash.yaml-sample
+++ b/config/gdash.yaml-sample
@@ -10,6 +10,18 @@
   :graph_width: 500
   :graph_height: 250
   :whisper_dir: "/var/lib/carbon/whisper"
+  :interval_filters:
+    - :label: Last Hour
+      :from: -1hour
+      :to: now
+    - :label: Last Day
+      :from: -1day
+    - :label: Last Week
+      :from: -1week
+    - :label: Last Month
+      :from: -1month
+    - :label: Last Year
+      :from: -1year
   :intervals:
     - [ "-1hour", "1 hour" ]
     - [ "-2hour", "2 hour" ]

--- a/lib/gdash.rb
+++ b/lib/gdash.rb
@@ -9,23 +9,27 @@ class GDash
   require 'gdash/sinatra_app'
   require 'graphite_graph'
 
-  attr_reader :graphite_base, :graphite_render, :dash_templates, :height, :width
+  attr_reader :graphite_base, :graphite_render, :dash_templates, :height, :width, :from, :until
 
-  def initialize(graphite_base, render_url, dash_templates, width=500, height=250)
+  def initialize(graphite_base, render_url, dash_templates, options={})
     @graphite_base = graphite_base
     @graphite_render = [@graphite_base, "/render/"].join
     @dash_templates = dash_templates
-    @height = height
-    @width = width
+    @height = options.delete(:height)
+    @width = options.delete(:width)
+    @from = options.delete(:from)
+    @until = options.delete(:until)
 
     raise "Dashboard templates directory #{@dash_templates} does not exist" unless File.directory?(@dash_templates)
   end
 
-  def dashboard(name, width=nil, height=nil)
-    width ||= @width
-    height ||= @height
+  def dashboard(name, options={})
+    options[:width] ||= @width
+    options[:height] ||= @height
+    options[:from] ||= @from
+    options[:until] ||= @until
 
-    Dashboard.new(name, dash_templates, width, height)
+    Dashboard.new(name, dash_templates, options)
   end
 
   def list

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -2,30 +2,41 @@ class GDash
   class Dashboard
     attr_accessor :properties
 
-    def initialize(short_name, dir, graph_width=500, graph_height=250)
+    def initialize(short_name, dir, options={})
       raise "Cannot find dashboard directory #{dir}" unless File.directory?(dir)
 
-      @properties = {}
+      @properties = {:graph_width => nil,
+                     :graph_height => nil,
+                     :graph_from => nil,
+                     :graph_until => nil}
 
       @properties[:short_name] = short_name
       @properties[:directory] = File.join(dir, short_name)
       @properties[:yaml] = File.join(dir, short_name, "dash.yaml")
-      @properties[:graph_width] = graph_width
-      @properties[:graph_height] = graph_height
 
       raise "Cannot find YAML file #{yaml}" unless File.exist?(yaml)
 
       @properties.merge!(YAML.load_file(yaml))
+
+      # Properties defined in dashboard config file are overridden when given on initialization
+      @properties[:graph_width] = options.delete(:width) || graph_width
+      @properties[:graph_height] = options.delete(:height) || graph_height
+      @properties[:graph_from] = options.delete(:from) || graph_from
+      @properties[:graph_until] = options.delete(:until) || graph_until
     end
 
-    def graphs(width=nil, height=nil)
-      height ||= graph_height
-      width ||= graph_width
+    def graphs(options={})
+      options[:width] ||= graph_width
+      options[:height] ||= graph_height
+      options[:from] ||= graph_from
+      options[:until] ||= graph_until
 
       graphs = Dir.entries(directory).select{|f| f.match(/\.graph$/)}
 
+      overrides = options.reject { |k,v| v.nil? }
+
       graphs.sort.map do |graph|
-        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), {:height => height, :width => width})}
+        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), overrides)}
       end
     end
 

--- a/views/_interval_filter.erb
+++ b/views/_interval_filter.erb
@@ -1,0 +1,5 @@
+<ul class="pills" style="margin-bottom: 0px;">
+  <% @interval_filters.each do |options| %>
+  <li<%= ' class="active"' if options[:from] == @dashboard.graph_from %>><%= link_to_interval(options) %></li>
+  <% end %>
+</ul>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,5 +1,6 @@
 <% unless @error %>
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<%= erb :_interval_filter, :layout => false unless @interval_filters.empty? %>
 <div class="row">
     <table>
     <% row = 1 %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,5 +1,5 @@
 <% unless @error %>
-<%   @top_level.each do |key, value| %>
+<%   @top_level.keys.sort.each do |key| %>
 <h2> <%= key.capitalize %> </h2>
 <table>
     <thead>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -18,7 +18,7 @@
                     <div class="container">
                         <h3><a href="<%= @prefix %>/"><%= @dash_title %></a></h3>
                         <ul class="nav">
-                        <% @top_level.each_key do |category| %>
+                        <% @top_level.keys.sort.each do |category| %>
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle"><%= category.capitalize %></a>
                                 <ul class="dropdown-menu">


### PR DESCRIPTION
I have added options to set the graph dimensions or interval period with url (inspirited by nathan-opscode  https://github.com/ripienaar/gdash/pull/14 commits).

Eg:

```
http://gdash.example.com/dashboard/email/?from=-8d&until=-7d
http://gdash.example.com/dashboard/email/full/2/600/300?from=-8d&until=-7d
http://gdash.example.com/dashboard/email/full/4?width=600&height=300&from=-8d&until=-7d
```

There is also a optional configurable interval quick filter for dashboards.

Also dashboard based default dimension and interval settings are configurable via dashboard _dash.yml_ file.
