### PR TITLE
Extra properties and include other dashboards in the dash.yaml 

### DIFF
--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -42,6 +42,21 @@ class GDash
       options[:height] ||= graph_height
       options[:from] ||= graph_from
       options[:until] ||= graph_until
+        
+      if @properties[:include] == nil || @properties[:include].empty?
+        includes = []
+      elsif @properties[:include].is_a? Array
+        includes = @properties[:include]
+      elsif @properties[:include].is_a? String
+        includes = [@properties[:include]]
+      else
+        raise "Invalid value from includes"
+      end
+
+      directories = includes.map { |d|
+        File.join(directory, '..', '..', d)
+      }
+      directories << directory
 
       graphs = list_graphs(directories)
 
@@ -49,11 +64,7 @@ class GDash
 
       graphs.keys.sort.map do |graph_name|
         {:name => graph_name, 
-         :graphite => GraphiteGraph.new(graphs[graph_name], 
-                      {:height => height, :width => width}, 
-                       overrides, 
-                       @properties[:graph_properties])}
-                       
+         :graphite => GraphiteGraph.new(graphs[graph_name], overrides, {}, @properties[:graph_properties])}
       end
     end
 

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -25,7 +25,7 @@ class GDash
       graphs = Dir.entries(directory).select{|f| f.match(/\.graph$/)}
 
       graphs.sort.map do |graph|
-        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), {:height => height, :width => width})}
+        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), {:height => height, :width => width}, {}, @properties[:graph_properties])}
       end
     end
 

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -18,14 +18,46 @@ class GDash
       @properties.merge!(YAML.load_file(yaml))
     end
 
+    def list_graphs(directories)
+      graphs = {}
+      directories.each { |directory|
+        current_graphs = Dir.entries(directory).select {|f| f.match(/\.graph$/)}
+        current_graphs.each { |graph_filename|  
+          graph_name = File.basename(graph_filename, ".graph")
+          graphs[graph_name] = File.join(directory, graph_filename) 
+        }
+      }
+      graphs
+    end
+
     def graphs(width=nil, height=nil)
       height ||= graph_height
       width ||= graph_width
+        
+      if @properties[:include] == nil || @properties[:include].empty?
+        includes = []
+      elsif @properties[:include].is_a? Array
+        includes = @properties[:include]
+      elsif @properties[:include].is_a? String
+        includes = [@properties[:include]]
+      else
+        raise "Invalid value from includes"
+      end
 
-      graphs = Dir.entries(directory).select{|f| f.match(/\.graph$/)}
+      directories = includes.map { |d|
+        File.join(directory, '..', '..', d)
+      }
+      directories << directory
 
-      graphs.sort.map do |graph|
-        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), {:height => height, :width => width}, {}, @properties[:graph_properties])}
+      graphs = list_graphs(directories)
+
+      graphs.keys.sort.map do |graph_name|
+        {:name => graph_name, 
+         :graphite => GraphiteGraph.new(graphs[graph_name], 
+                      {:height => height, :width => width}, 
+                       {}, 
+                       @properties[:graph_properties])}
+                       
       end
     end
 

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -74,9 +74,7 @@ class GDash
 
       if main_graph = @dashboard.graphs[params[:name].to_i][:graphite]
         @graphs = @intervals.map do |e|
-          new_props = {:from => e[0], :title => "#{main_graph.properties[:title]} - #{e[1]}"}
-          new_props = main_graph.properties.merge new_props
-          GraphiteGraph.new(main_graph.file, new_props)
+          new_graph = main_graph.clone_new_interval(e)
         end
       else
         @error = "No such graph available"


### PR DESCRIPTION
Added support to specify extra properties  using the key ':graph_properties'. These properties can be and used in
the graphs as normal ruby code. Also allow include all the graphs specified in other dashboard (or any subdirectory in the dashboards directory).

Example::

 :name: Java core metrics.
 :description: Different java process metrics.
 :include: [ "jvm/heap" ]
 :graph_properties:
  :environment: dev
  :servers: [ server1, server2, server3, server4  ]

And in the Graph:

 title       "Heap memory for #{environment} machines"
 timezone    "Europe/London"
 vtitle      "size"
 linewidth   2
 linemode    "connected"
 description "Java Memory Usage in all machines in #{environment}"

 field :heapmax, :alias => "Heap Max",
                 :data  => "sumSeries(servers.java.caspercore.#{environment}.#{servers[0]}.jvm-heap.HeapMemoryUsage_max)"

 servers.each do |servername|
   field "heap_used_#{servername}".to_sym,
   :alias => "Heap Used #{servername}",
   :data  => "servers.java.caspercore.#{environment}.#{servername}.jvm-heap.HeapMemoryUsage_used"
 end
