### PR TITLE
Add screen shot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A simple Graphite dashboard built using Twitter's Bootstrap.
 Adding new dashboards is very easy and individual graphs are
 described using a small DSL.
 
-See the _sample_ directory for an example dashboard including
-a screenshot.
+See the _sample_ directory for a sample dashboard configuration.
+
+![Sample dashboard](https://github.com/ripienaar/gdash/raw/master/sample/email.png)
 
 Config?
 -------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 What?
 =====
 
-A simple Graphite dashboard built using Twitters Bootstrap.
+A simple Graphite dashboard built using Twitter's Bootstrap.
 
-Adding new dashboards is very easy and individual graphs is
+Adding new dashboards is very easy and individual graphs are
 described using a small DSL.
 
 See the _sample_ directory for an example dashboard including


### PR DESCRIPTION
A screen shot in README is good for people who encounter the project for the first time as it immediately tells what to expect from the final results -- people often look at a screen shot even before they read anything.  In this particular case it also clearly shows that the project utilizes Graphite's graphs and not its own (as [Graphene](http://jondot.github.com/graphene/) does, for example).
