### PR TITLE
Change the refresh behavior for graphs.

### DIFF
--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta http-equiv="refresh" content="60">
+    <script src="<%= @prefix %>/js/jquery-1.5.2.min.js"></script>
 </head>
 <% if @error %>
    <h2><%= @error %></h2>
@@ -19,6 +19,18 @@
         </tr>
     <% end %>
 </table>
+<script>
+    $(document).ready(function() {
+        setInterval(reloadDash, <%= @refresh_rate * 1000 %>);
+    });
+    function reloadDash() {
+        var now = new Date();
+        $('img').each(function(index) {
+            var url = $(this).attr('src').replace(/&\d+$/, '');
+            $(this).attr('src', url + '&' + now.getTime());
+        });
+    }
+</script>
 </body>
 <% end %>
 </html>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -9,7 +9,6 @@
         <script src="<%= @prefix %>/js/bootstrap-dropdown.js"></script>
         <script src="<%= @prefix %>/js/bootstrap-popover.js"></script>
         <title><%= @dash_title %></title>
-        <meta http-equiv="refresh" content="<%= @refresh_rate %>">
     </head>
     <body style="padding-top: 80px;">
         <div class="topbar-wrapper" style="z-index: 5;">
@@ -47,7 +46,22 @@
                 <%= yield %>
         </div>
         <div class="container">
-            <h6>Updated <%= Time.now %></h6>
+            <h6 id="updated"></h6>
         </div>
+        <script>
+            $(document).ready(function() {
+                var now = new Date();
+                $('#updated').text('Updated ' + now.toLocaleString())
+                setInterval(reloadDash, <%= @refresh_rate * 1000 %>);
+            });
+            function reloadDash() {
+                var now = new Date();
+                $('img').each(function(index) {
+                    var url = $(this).attr('src').replace(/&\d+$/, '');
+                    $(this).attr('src', url + '&' + now.getTime());
+                });
+                $('#updated').text('Updated ' + now.toLocaleString())
+            }
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Instead of a meta refresh, use javascript to
update the src of the images so you don't
get a full page reload. It makes the dashboard
work in a nicer way.

The full screen dashboard was also hardcoded to
a 60 second interval. Have it use the config value
instead.
