### PR TITLE
gdash should require 'sinatra/base' not 'sinatra'

### DIFF
--- a/lib/gdash.rb
+++ b/lib/gdash.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'sinatra'
+require 'sinatra/base'
 require 'yaml'
 require 'erb'
 require 'redcarpet'


### PR DESCRIPTION
`gdash.rb` should `require 'sinatra/base'` not `sinatra` otherwise you get the sinatra DSL imported into Object. From the sinatra documentation:

```
Your file should require sinatra/base instead of sinatra; otherwise, all of Sinatra's DSL methods are imported into the main namespace.
```

See: http://www.sinatrarb.com/intro
