### PR TITLE
Use graphite_graph >= 0.0.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 gem 'sinatra'
 gem 'redcarpet'
-gem 'graphite_graph'
+gem 'graphite_graph', "~>0.0.6"


### PR DESCRIPTION
If I use gem install graphite_graph, it downloads 0.0.6 version.
Bit if I use bundler (in gdash cookbook) and without this patch, it dowloads only 0.0.4, don't not why.
