### PR TITLE
Support for includes and properties in dash.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ that can be accessed from the .graph like:
         :alias => "IO Wait #{server}",
         :data  => "servers.#{environment}.#{server}.cpu*.cpu-{system,wait}.value"
 
+Include graphs from other dashboard?
+------------------------------------
+
+You can include the graphs from other dashboard with the include 
+property in dash.yaml:
+
+    :include: 
+    - "templates/os.basic" 
+    - "templates/os.nfs" 
 
 Contact?
 --------

--- a/README.md
+++ b/README.md
@@ -171,6 +171,26 @@ _600_ and a height of _300_
 
 The screen will refresh every minute
 
+Additional properties in graphs?
+--------------------------------
+
+You can specify additional properties in the dash.yaml:
+
+    :graph_properties:
+        :environment: dev
+        :server: [ a_server_name ]
+        :javaid: 1234
+    
+that can be accessed from the .graph like:
+    
+    server = @properties[:server]
+    environment = @properties[:environment]
+    
+    field :iowait, 
+        :alias => "IO Wait #{server}",
+        :data  => "servers.#{environment}.#{server}.cpu*.cpu-{system,wait}.value"
+
+
 Contact?
 --------
 

--- a/lib/gdash.rb
+++ b/lib/gdash.rb
@@ -10,12 +10,14 @@ class GDash
   require 'gdash/sinatra_app'
   require 'graphite_graph'
 
-  attr_reader :graphite_base, :graphite_render, :dash_templates, :height, :width, :from, :until
+  attr_reader :graphite_base, :graphite_render, :graph_templates, :category, :dash_templates, :height, :width, :from, :until
 
-  def initialize(graphite_base, render_url, dash_templates, options={})
+  def initialize(graphite_base, render_url, graph_templates, category,  options={})
     @graphite_base = graphite_base
     @graphite_render = [@graphite_base, "/render/"].join
-    @dash_templates = dash_templates
+    @graph_templates = graph_templates
+    @category = category
+    @dash_templates = File.join(graph_templates, category)
     @height = options.delete(:height)
     @width = options.delete(:width)
     @from = options.delete(:from)
@@ -30,7 +32,7 @@ class GDash
     options[:from] ||= @from
     options[:until] ||= @until
 
-    Dashboard.new(name, dash_templates, options)
+    Dashboard.new(name, graph_templates, category, options)
   end
 
   def list

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -34,6 +34,7 @@ class GDash
       graphs = Dir.entries(directory).select{|f| f.match(/\.graph$/)}
 
       overrides = options.reject { |k,v| v.nil? }
+      overrides = overrides.merge!(@properties[:graph_properties])
 
       graphs.sort.map do |graph|
         {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), overrides)}

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -2,17 +2,20 @@ class GDash
   class Dashboard
     attr_accessor :properties
 
-    def initialize(short_name, dir, options={})
-      raise "Cannot find dashboard directory #{dir}" unless File.directory?(dir)
-
+    def initialize(short_name, graph_templates, category, options={})
       @properties = {:graph_width => nil,
                      :graph_height => nil,
                      :graph_from => nil,
                      :graph_until => nil}
 
       @properties[:short_name] = short_name
-      @properties[:directory] = File.join(dir, short_name)
-      @properties[:yaml] = File.join(dir, short_name, "dash.yaml")
+      @properties[:graph_templates] = graph_templates
+      @properties[:category] = category
+      @properties[:directory] = File.join(graph_templates, category, short_name)
+      
+      raise "Cannot find dashboard directory #{directory}" unless File.directory?(directory)
+      
+      @properties[:yaml] = File.join(directory, "dash.yaml")
 
       raise "Cannot find YAML file #{yaml}" unless File.exist?(yaml)
 
@@ -25,19 +28,47 @@ class GDash
       @properties[:graph_until] = options.delete(:until) || graph_until
     end
 
+    def list_graphs(directories)
+      graphs = {}
+      directories.each { |directory|
+        current_graphs = Dir.entries(directory).select {|f| f.match(/\.graph$/)}
+        current_graphs.each { |graph_filename|  
+          graph_name = File.basename(graph_filename, ".graph")
+          graphs[graph_name] = File.join(directory, graph_filename) 
+        }
+      }
+      graphs
+    end
+
     def graphs(options={})
       options[:width] ||= graph_width
       options[:height] ||= graph_height
       options[:from] ||= graph_from
       options[:until] ||= graph_until
 
-      graphs = Dir.entries(directory).select{|f| f.match(/\.graph$/)}
-
       overrides = options.reject { |k,v| v.nil? }
       overrides = overrides.merge!(@properties[:graph_properties])
 
-      graphs.sort.map do |graph|
-        {:name => File.basename(graph, ".graph"), :graphite => GraphiteGraph.new(File.join(directory, graph), overrides)}
+      if @properties[:include] == nil || @properties[:include].empty?
+        includes = []
+      elsif @properties[:include].is_a? Array
+        includes = @properties[:include]
+      elsif @properties[:include].is_a? String
+        includes = [@properties[:include]]
+      else
+        raise "Invalid value for include in #{File.join(directory, 'graph.yaml')}"
+      end
+
+      directories = includes.map { |d|
+        File.join(graph_templates, d)
+      }
+      directories << directory
+
+      graphs = list_graphs(directories)
+
+      graphs.keys.sort.map do |graph_name|
+        {:name => graph_name, 
+         :graphite => GraphiteGraph.new(graphs[graph_name], overrides)}
       end
     end
 

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -47,7 +47,7 @@ class GDash
       options[:until] ||= graph_until
 
       overrides = options.reject { |k,v| v.nil? }
-      overrides = overrides.merge!(@properties[:graph_properties])
+      overrides = overrides.merge!(@properties[:graph_properties]) if @properties[:graph_properties]
 
       if @properties[:include] == nil || @properties[:include].empty?
         includes = []

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -39,8 +39,10 @@ class GDash
       @top_level = Hash.new
       Dir.entries(@graph_templates).each do |category|
         if File.directory?("#{@graph_templates}/#{category}")
+          
           unless ("#{category}" =~ /^\./ )
-            @top_level["#{category}"] = GDash.new(@graphite_base, "/render/", File.join(@graph_templates, "/#{category}"), {:width => @graph_width, :height => @graph_height})
+            gdash = GDash.new(@graphite_base, "/render/", @graph_templates, category, {:width => @graph_width, :height => @graph_height})
+            @top_level["#{category}"] = gdash unless gdash.dashboards.empty?
           end
         end
       end


### PR DESCRIPTION
Two new features:
- Allow override graph properties from the dash.yaml. 
- Support include the graphs from other dashboards in dash.yaml

These two features allow you create a set of templates that you can include and parametrize, like this:

```
└── graph_templates
    ├── live
    │   ├── 3_OS_server0001
    │   │   └── dash.yaml
    │   ├── 3_OS_server0002
    │   │   └── dash.yaml
    │   ├── 3_OS_live_all
    │   │   └── dash.yaml
    └── templates
        ├── os.basic
        │   ├── 10-cpu.graph
        │   ├── 20-load.graph
        │   ├── 25-memory.graph
        │   ├── 26-swap-io.graph
        │   ├── 30-network.graph
        │   ├── 40-processes.graph
        │   ├── 80-io.graph
        │   ├── 81-io-time.graph
        │   ├── 82-io-ops.graph
        │   └── 90-df.graph
        ├── os.basic_multi
        │   ├── 10-cpu-multi.graph
        │   ├── 30-network-multi.graph
        │   ├── 80-io-multi.graph
        │   ├── 81-io-time-multi.graph
        │   └── 82-io-ops-multi.graph
        ├── os.marklogic
        │   ├── 92-ml-volumes-df.graph
        │   └── 93-ml-volumes-df.graph
        └── os.nfs
             ├── 91-nfs-basic.graph
             ├── 92-nfs-detailed.graph
             └── 93-slabinfo.graph
```

In the dash.yaml you can include the graphs as an include and override some properties:

``` yaml
:name: "OS slnldogo0002"
:description: "OS slnldogo0002: slnldogo0002_springer-sbm_com"

:include: 
 - "templates/os.basic" 
 - "templates/os.nfs" 
:graph_properties: 
 :environment: live
 :servers: [ server0001, server0002 ]
```

And in the graphs:

``` ruby
title       "Combined CPU Usage"
vtitle      "percent"
linemode    "connected" 
timezone    "Europe/London"
description "The combined CPU usage for all core servers"

servers = @properties[:servers] 
environment = @properties[:environment] 

server_definition = (servers.is_a? Array) ? "{#{servers.join(',')}}" : servers

field :iowait, :scale => 0.1,
               :color => "yellow",
               :alias => "IO Wait",
               :data  => "sumSeries(nonNegativeDerivative(servers.#{server_definition}.cpu*.cpu-{system,wait}.value))",
               :smoothing => 3

field :user,   :scale => 0.1,
               :color => "green",
               :alias => "User",
               :data  => "sumSeries(nonNegativeDerivative(servers.#{server_definition}.cpu*.cpu-user.value))",
               :smoothing => 3

field :other,  :scale => 0.1,
               :color => "red",
               :alias => "Other",
               :data  => "sumSeries(nonNegativeDerivative(servers.#{server_definition}.cpu-*.cpu-{interrupt,softirq,steal}.value))",
               :smoothing => 3

field :idle,   :scale => 0.1,
               :color => "grey",
               :alias => "idle",
               :data  => "sumSeries(nonNegativeDerivative(servers.#{server_definition}.cpu-*.cpu-idle.value))",
               :smoothing => 3
```

We got to access this properties as  @properties[:servers]  because the missing_method disallows access the overrides directly, not sure why.
