### PR TITLE
Add a script to validate dashboards.

### DIFF
--- a/tools/dashboards-validation.rb
+++ b/tools/dashboards-validation.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-$LOAD_PATH << './lib'
 
 require 'optparse'
 require 'gdash'

--- a/tools/dashboards-validation.rb
+++ b/tools/dashboards-validation.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+$LOAD_PATH << './lib'
+
+require 'optparse'
+require 'gdash'
+require 'gdash/dashboard'
+
+options = {}
+
+opt_parser = OptionParser.new do |opt|
+  opt.banner = "Usage: " + opt.program_name + " [OPTIONS]"
+
+  opt.on("-p", "--path PATH", String, "dashboard path") do |path|
+    options[:path] = path
+  end
+
+  opt.on("-h","--help","help") do
+    puts opt_parser
+  end
+end
+
+begin
+  opt_parser.parse!
+  if options[:path].nil?
+    puts "Missing options path."
+    puts opt_parser
+    exit
+  end
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+  puts $!.to_s
+  puts opt_parser
+  exit
+end
+
+unless File.directory? options[:path]
+  puts "Path #{options[:path]} does not exists."
+  puts opt_parser
+  exit
+end
+
+Dir.foreach(options[:path]).each do |dashboard|
+  next if dashboard == '.' or dashboard == '..'
+  begin
+    graph_directory = File.join(options[:path], dashboard)
+
+    Dir.foreach(graph_directory).each do |category|
+      next if category == '.' or category == '..'
+      category_dir = File.join(graph_directory, category)
+      category_desc = File.join(category_dir, 'dash.yaml')
+
+      if !File.exists?(category_desc)
+        puts "The dashboard description file (" + category_desc + ") is missing."
+      end
+
+      graphs = Dir.entries(category_dir).select{|f| f.match(/\.graph$/)}
+      for graph in graphs
+        begin
+          full_path = File.join(category_dir, graph)
+          GraphiteGraph.new(full_path)
+        rescue Exception => e
+          puts "Can't parse the graph file " + full_path + ":"
+          puts "\t " + e.message
+        end
+      end
+    end
+  rescue Exception => e
+    p e
+  end
+end


### PR DESCRIPTION
This script validate that all the categories contains a description (the `dash.yaml` file), and that all the `.graph` files can be parsed with `GraphiteGraph`.

When a new graph is created, if there's a syntax error in the graph description, the application will be unable to display it.  If the dashboards are stored in some kind of repository, before pulling them to the server, or before pushing them, this script can be run to validate that the graphs can be loaded by `GraphiteGraph` and that all categories contains the dash description (e.g: a git hook, Jenkin's job, etc.)
