### PR TITLE
Added a "Print this page" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ A external properties files can be also loaded from the url:
 
   http://graphite.example.net:3000/category_name/dash_name/?include_properties=white-theme.yml
 
+Special properties when printing?
+---------------------------------
+
+When printing these properties will be overrided:  
+
+    :graph_properties: 
+     :background_color: white
+     :foreground_color: black
+
+You can create an optional YAML file _templatedir/print.yml_ that will be loaded when printing.
+This way you can override additional properties or use custom colors for printing.
+
 Contact?
 --------
 

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -42,8 +42,9 @@ class GDash
           @properties.rmerge!(YAML.load_file(yaml_file))
         end
       end
-
+ 	
       # Properties defined in dashboard config file are overridden when given on initialization
+      @properties.rmerge!(options)
       @properties[:graph_width] = options.delete(:width) || graph_width
       @properties[:graph_height] = options.delete(:height) || graph_height
       @properties[:graph_from] = options.delete(:from) || graph_from

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -40,8 +40,6 @@ class GDash
         yaml_file = File.join(graph_templates, property_file)
         if File.exist?(yaml_file)
           @properties.rmerge!(YAML.load_file(yaml_file))
-        else
-          raise "Missing file #{yaml_file}' for include_properties in #{File.join(directory, 'dash.yaml')}"
         end
       end
 

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -71,7 +71,7 @@ class GDash
       less :"bootstrap/#{params[:name]}", :paths => ["views/bootstrap"]
     end
 
-    get '/:category/:dash/details/:name' do
+    get '/:category/:dash/details/:name/?*' do
       options = {}
       if query_params[:print]
         options[:include_properties] = "print.yml"

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -122,6 +122,36 @@ class GDash
       erb :full_size_dashboard, :layout => false
     end
 
+    get '/:category/:dash/print/?*' do
+      options = {}
+      params["splat"] = params["splat"].first.split("/")
+
+      if params["splat"][0]
+        params["columns"] = params["splat"][0].to_i
+      else 
+        params["columns"] = @graph_columns
+      end
+
+      if params["splat"].size == 3
+        options[:width] = params["splat"][1].to_i
+        options[:height] = params["splat"][2].to_i
+      else
+        options[:width] = @graph_width
+        options[:height] = @graph_height
+      end
+
+      options[:include_properties] = "print.yml"
+      options.merge!(params)
+      
+      if @top_level["#{params[:category]}"].list.include?(params[:dash])
+        @dashboard = @top_level[@params[:category]].dashboard(params[:dash], options)
+      else
+        @error = "No dashboard called #{params[:dash]} found in #{params[:category]}/#{@top_level[params[:category]].list.join ','}"
+      end
+
+      erb :print_dashboard, :layout => false
+    end
+
     get '/:category/:dash/?*' do
       options = {}
       params["splat"] = params["splat"].first.split("/")

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -72,8 +72,18 @@ class GDash
     end
 
     get '/:category/:dash/details/:name' do
+      options = {}
+      if query_params[:print]
+        options[:include_properties] = "print.yml"
+        options[:graph_properties] = { 
+		:background_color => "white",
+		:foreground_color => "black"
+	}
+      end
+      options.merge!(query_params)
+
       if @top_level["#{params[:category]}"].list.include?(params[:dash])
-        @dashboard = @top_level[@params[:category]].dashboard(params[:dash])
+        @dashboard = @top_level[@params[:category]].dashboard(params[:dash], options)
       else
         @error = "No dashboard called #{params[:dash]} found in #{params[:category]}/#{@top_level[params[:category]].list.join ','}."
       end
@@ -94,7 +104,11 @@ class GDash
         @error = "No such graph available"
       end
 
-      erb :detailed_dashboard
+      if !query_params[:print]
+	erb :detailed_dashboard
+      else
+	erb :print_detailed_dashboard, :layout => false
+      end
     end
 
     get '/:category/:dash/full/?*' do
@@ -111,8 +125,6 @@ class GDash
         options[:height] = @graph_height
       end
 
-      options.merge!(query_params)
-
       if @top_level["#{params[:category]}"].list.include?(params[:dash])
         @dashboard = @top_level[@params[:category]].dashboard(params[:dash], options)
       else
@@ -120,36 +132,6 @@ class GDash
       end
 
       erb :full_size_dashboard, :layout => false
-    end
-
-    get '/:category/:dash/print/?*' do
-      options = {}
-      params["splat"] = params["splat"].first.split("/")
-
-      if params["splat"][0]
-        params["columns"] = params["splat"][0].to_i
-      else 
-        params["columns"] = @graph_columns
-      end
-
-      if params["splat"].size == 3
-        options[:width] = params["splat"][1].to_i
-        options[:height] = params["splat"][2].to_i
-      else
-        options[:width] = @graph_width
-        options[:height] = @graph_height
-      end
-
-      options[:include_properties] = "print.yml"
-      options.merge!(params)
-      
-      if @top_level["#{params[:category]}"].list.include?(params[:dash])
-        @dashboard = @top_level[@params[:category]].dashboard(params[:dash], options)
-      else
-        @error = "No dashboard called #{params[:dash]} found in #{params[:category]}/#{@top_level[params[:category]].list.join ','}"
-      end
-
-      erb :print_dashboard, :layout => false
     end
 
     get '/:category/:dash/?*' do
@@ -162,6 +144,13 @@ class GDash
           options[:until] = params["splat"][2] || "now"
         end
 
+      if query_params[:print]
+        options[:include_properties] = "print.yml"
+        options[:graph_properties] = { 
+		:background_color => "white",
+		:foreground_color => "black"
+	}
+      end
       options.merge!(query_params)
 
       if @top_level["#{params[:category]}"].list.include?(params[:dash])
@@ -170,7 +159,11 @@ class GDash
         @error = "No dashboard called #{params[:dash]} found in #{params[:category]}/#{@top_level[params[:category]].list.join ','}."
       end
 
-      erb :dashboard
+      if !query_params[:print]
+	erb :dashboard
+      else
+	erb :print_dashboard, :layout => false
+      end
     end
 
     get '/docs/' do
@@ -195,6 +188,13 @@ class GDash
         end
 
         hash
+      end
+
+      def link_to_print
+	uri =  URI.parse(request.path)
+	new_query_ar = URI.decode_www_form(request.query_string) << ["print", "1"]
+	uri.query = URI.encode_www_form(new_query_ar)
+	uri.to_s
       end
     end
   end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -35,6 +35,8 @@
                                     <li class="divider"></li>
                                     <li><a href="<%= @prefix %>/docs/">GDash Docs</a></li>
                                     <li><a href="http://graphite.readthedocs.org/en/1.0/functions.html">Graphite Function Reference</a></li>
+                                    <li class="divider"></li>
+                                    <li><a href="<%= [@prefix, params[:category], @params[:dash], 'print'].join('/')%>" target="_blank">Print this page</a></li> 
                                 </ul>
                             </li>
 			            </ul>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -27,10 +27,18 @@
                             </li>
                         <% end %>
                         </ul>
-                        <ul class="nav pull-right">
-                            <li><a href="<%= @graphite_base %>">Data Browser</a></li>
-                            <li><a href="<%= @prefix %>/docs/">Docs</a></li>
-                        </ul>
+  			            <ul class="nav secondary-nav">
+                            <li class="dropdown">
+                                <a href="#" class="dropdown-toggle">Menu</a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="<%= @graphite_base %>">Data Browser</a></li>
+                                    <li class="divider"></li>
+                                    <li><a href="<%= @prefix %>/docs/">GDash Docs</a></li>
+                                    <li><a href="http://graphite.readthedocs.org/en/1.0/functions.html">Graphite Function Reference</a></li>
+                                </ul>
+                            </li>
+			            </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -35,8 +35,10 @@
                                     <li class="divider"></li>
                                     <li><a href="<%= @prefix %>/docs/">GDash Docs</a></li>
                                     <li><a href="http://graphite.readthedocs.org/en/1.0/functions.html">Graphite Function Reference</a></li>
-                                    <li class="divider"></li>
-                                    <li><a href="<%= [@prefix, params[:category], @params[:dash], 'print'].join('/')%>" target="_blank">Print this page</a></li> 
+                                    <% if @dashboard %>
+                                        <li class="divider"></li>
+                                        <li><a href="<%= link_to_print %>" target="_blank">Print this page</a></li>
+                                    <% end %> 
                                 </ul>
                             </li>
 			            </ul>

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -17,7 +17,7 @@ setTimeout("window.close();",1000);
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 
 <table width="100%" height="100%">
-    <% @dashboard.graphs.in_groups_of(params["columns"]) do |graphs| %>
+    <% @dashboard.graphs.in_groups_of(@graph_columns) do |graphs| %>
         <tr>
         <% graphs.each do |graph| %>
             <td valign="middle" align="center">

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -17,9 +17,9 @@ setTimeout("window.close();",1000);
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 
 <table width="100%" height="100%">
-    <% @dashboard.graphs.in_groups_of(@graph_columns) do |graphs| %>
+    <% @graphs.in_groups_of(@graph_columns) do |graphrows| %>
         <tr>
-        <% graphs.each do |graph| %>
+        <% graphrows.each do |graph| %>
             <td valign="middle" align="center">
             <% if graph %>
                 <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>'>

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -1,0 +1,46 @@
+<html>
+<head>
+    <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
+    <script language=Javascript>
+window.print();
+ClosePrint();
+function ClosePrint( )
+{
+setTimeout("window.close();",1000);
+}
+    </script>
+</head>
+<% if @error %>
+   <h2><%= @error %></h2>
+<% else %>
+<body bgcolor="white">
+<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+
+<table width="100%" height="100%">
+    <% @dashboard.graphs.in_groups_of(params["columns"]) do |graphs| %>
+        <tr>
+        <% graphs.each do |graph| %>
+            <td valign="middle" align="center">
+            <% if graph %>
+                <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>'>
+            <% end %>
+            </td>
+        <% end %>
+        </tr>
+    <% end %>
+</table>
+<script>
+    $(document).ready(function() {
+        setInterval(reloadDash, <%= @refresh_rate * 1000 %>);
+    });
+    function reloadDash() {
+        var now = new Date();
+        $('img').each(function(index) {
+            var url = $(this).attr('src').replace(/&\d+$/, '');
+            $(this).attr('src', url + '&' + now.getTime());
+        });
+    }
+</script>
+</body>
+<% end %>
+</html>

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -23,11 +23,7 @@ setTimeout("window.close();",1000);
           <% graphrows.each do |graph| %>
             <td>
             <% if graph %>
-                <% if graph[:description] %>
-                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>' rel="<%= row == 1 ? 'popover-below' : 'popover-above' %>" title="<%= graph[:title] %>" data-content="<%= graph[:description] %>">
-                <% else %>
-                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>'>
-                <% end %>
+              <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
             <% end %>
             </td>
           <% end %>

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
+    <script language=Javascript>
+window.print();
+ClosePrint();
+function ClosePrint( )
+{
+setTimeout("window.close();",1000);
+}
+    </script>
+</head>
+<body bgcolor="white">
+<% if @error %>
+   <h2><%= @error %></h2>
+<% else %>
+<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<div class="row">
+    <table>
+        <% row = 1 %>
+        <% @graphs.in_groups_of(@graph_columns) do |graphrows| %>
+          <tr>
+          <% graphrows.each do |graph| %>
+            <td>
+            <% if graph %>
+                <% if graph[:description] %>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>' rel="<%= row == 1 ? 'popover-below' : 'popover-above' %>" title="<%= graph[:title] %>" data-content="<%= graph[:description] %>">
+                <% else %>
+                    <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:url]].join "?" %>'>
+                <% end %>
+            <% end %>
+            </td>
+          <% end %>
+	  </tr>
+          <% row += 1 %>
+        <% end %>
+    </table>
+</div>
+<% end %>
+</body>
+</html>
+


### PR DESCRIPTION
I like the graphs be white on black on my screen... but in some cases I want to print the page, and the ink is more expensive than my own blood.

The Print this page feature will create a black on white version of the current page, and open the print dialog, removing unnecessary headers.

You can also create some custom properties to use in printing mode.

Note: Requires and includes PR #68 
