### PR TITLE
Sort the dashboard graphs by the name of the file in the directory, instead of the name displayed

### DIFF
--- a/lib/gdash.rb
+++ b/lib/gdash.rb
@@ -45,13 +45,14 @@ class GDash
       begin
         yaml_file = File.join(dash_templates, dash, "dash.yaml")
         if File.exist?(yaml_file)
-          dashboards << YAML.load_file(yaml_file).merge({:link => dash})
+          dashboard = YAML.load_file(yaml_file).merge({:link => dash})
+          dashboard[:dash_id] = dash
+          dashboards << dashboard
         end
       rescue Exception => e
         p e
       end
     end
-
     dashboards.sort_by{|d| d[:name].to_s}
   end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -7,7 +7,7 @@
         <th width="70%">Description</th>
     </thead>
     <tbody>
-        <% @top_level[key].dashboards.sort_by{|b| b[:name].to_s}.each do |board| %>
+        <% @top_level[key].dashboards.sort_by{|b| b[:dash_id].to_s}.each do |board| %>
         <tr>
             <td><a href="<%= [@prefix, key, board[:link]].join('/') %>/"><%= board[:name] %></a></td><td><%= board[:description] %></td>
         </tr>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -20,7 +20,7 @@
                           <li class="dropdown" id="menu-<%= category %>">
                                 <a href="#" data-toggle="dropdown" href="#menu-<%= category %>" class="dropdown-toggle"><%= category.capitalize %> <b class="caret"></b></a>
                                 <ul class="dropdown-menu">
-                                <% @top_level[category].dashboards.sort_by{|b| b[:name].to_s}.each do |board| %>
+                                <% @top_level[category].dashboards.sort_by{|b| b[:dash_id].to_s}.each do |board| %>
                                     <li><a href="<%= [@prefix, category, board[:link]].join('/') %>/"><%= board[:name] %></a></li>
                                 <% end %>
                                 </ul>


### PR DESCRIPTION
This patch will enforce the order of the graphs based on the graph filename. This allows you force a graph order without change the title. 
