### PR TITLE
URL parameter placeholders in graph definitions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ gem 'sinatra'
 gem 'redcarpet'
 gem 'less'
 gem 'therubyracer'
-gem 'graphite_graph', "~>0.0.7"
+gem 'graphite_graph', "~>0.0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     commonjs (0.2.6)
-    graphite_graph (0.0.7)
+    graphite_graph (0.0.8)
     less (2.2.1)
       commonjs (~> 0.2.6)
     libv8 (3.3.10.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  graphite_graph (~> 0.0.7)
+  graphite_graph (~> 0.0.8)
   less
   redcarpet
   sinatra

--- a/README.md
+++ b/README.md
@@ -238,6 +238,19 @@ A external properties files can be also loaded from the url:
 
   http://graphite.example.net:3000/category_name/dash_name/?include_properties=white-theme.yml
 
+Placeholder Parameters
+----------------
+
+Provide variables in the URL:
+
+  http://graphite.example.net:3000/category_name/dash_name/?p[node]=node.example.net
+
+And use them in the graphs
+
+    field :iowait, 
+        :data  => "servers.%{node}.cpu*.cpu-wait.value"
+
+
 Contact?
 --------
 

--- a/lib/gdash.rb
+++ b/lib/gdash.rb
@@ -33,6 +33,7 @@ class GDash
     options[:from] ||= @from
     options[:until] ||= @until
 
+
     Dashboard.new(name, graph_templates, category, options, graphite_render)
   end
 

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -124,4 +124,3 @@ class GDash
     end
   end
 end
-  

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -5,7 +5,7 @@
 <div class="row">
     <table>
     <% row = 1 %>
-    <% grouped_graphs = @dashboard.graphs.in_groups_of(@graph_columns) %>
+    <% grouped_graphs = @graphs.in_groups_of(@graph_columns) %>
     <% grouped_graphs.each do |graphs| %>
         <tr>
         <% graphs.each do |graph| %>

--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -7,7 +7,7 @@
 <% else %>
 <body bgcolor="black">
 <table width="100%" height="100%">
-    <% @dashboard.graphs.in_groups_of(params["columns"]) do |graphs| %>
+    <% @graphs.in_groups_of(params["columns"]) do |graphs| %>
         <tr>
         <% graphs.each do |graph| %>
             <td valign="middle" align="center">

--- a/views/graph.erb
+++ b/views/graph.erb
@@ -1,7 +1,8 @@
 <% omit_link ||= false %>
 <div class="graph span6">
   <% unless omit_link %>
-    <a href='<%= [@prefix, params[:category], @params[:dash], 'details', graph[:name]].join "/" %>'>
+    <%qp=""; params['p'].each {|k,v| qp+="?p[#{k}]=#{v}"} unless params['p'].nil?%>
+    <a href='<%= [@prefix, params[:category], @params[:dash], 'details', graph[:name], qp].join "/" %>'>
   <% end %>
   <img class="thumbnail" src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>' title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
   <% unless omit_link %>


### PR DESCRIPTION
This lets us call something like
    `http://graphite.example.net/system/common/details/cpu/?p[node]=somenode.example.net`

And refer to that node in the graph definitions like so
    `:data  => "servers.%{node}.cpu*.cpu-wait.value"`

This PR inspired by tanelj/gdash@0b4560900.
