### PR TITLE
Placeholders graph properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ A external properties files can be also loaded from the url:
   http://graphite.example.net:3000/category_name/dash_name/?include_properties=white-theme.yml
 
 Placeholder Parameters
-----------------
+----------------------
 
 Provide variables in the URL:
 
@@ -250,6 +250,14 @@ And use them in the graphs
     field :iowait, 
         :data  => "servers.%{node}.cpu*.cpu-wait.value"
 
+It will also override any graph properties as in the :graph_properties: in dash.yaml, so
+the value can be accessed using the @properties hash:
+
+    node = @properties[:node]
+
+Also can be used to override graph properties like the timezone:
+
+  http://graphite.example.net:3000/category_name/dash_name/?p[timezone]=CET
 
 Contact?
 --------

--- a/lib/gdash/dashboard.rb
+++ b/lib/gdash/dashboard.rb
@@ -92,6 +92,7 @@ class GDash
 
       overrides = options.reject { |k,v| v.nil? }
       overrides = overrides.merge!(@properties[:graph_properties]) if @properties[:graph_properties]
+      overrides = overrides.merge!(options[:placeholders]) if options[:placeholders]
 
       graphs = list_graphs
 
@@ -109,6 +110,7 @@ class GDash
 
       overrides = options.reject { |k,v| v.nil? }
       overrides = overrides.merge!(@properties[:graph_properties]) if @properties[:graph_properties]
+      overrides = overrides.merge!(options[:placeholders]) if options[:placeholders]
 
       graphs = list_graphs
 


### PR DESCRIPTION
I am not sure if the implementation of the placeholders is the best solution (see https://github.com/ripienaar/graphite-graph-dsl/pull/9 and #72) 

I would rather use normal properties (overrides parameter in GraphiteGraph constructor) and normal ruby string interpolation.

Some drawbacks are:
- It is limited by the %{key} syntax, where the #{expression} is normal ruby.
- Programmers are used to string interpolation.
- In gdash we implemented the "expanded includes" and "override graph properties" functions (see #59). We should integrate this with those features allowing override the graph_properties defined in the dash.yaml.
- It does not support multivalue.

In this commit, I just added logic to override the graph_properties using the placeholders hash. This way you can:
- Override any :graph_properties: defined in the dash.yaml
- Override other properties in the graph, like the 'timezone'

Anyway, I think is better also keep the current placeholder functionality as it has been added to the graphite-graph-dsl and the gdash master branches.

For example, in this dash.yaml:

```
:name: "core"
:description: "core metrics"

:graph_properties: 
 :environment: live
 :servers: [ server1.example.com, server2.example.com, server3.example.com ]
 :javaid: core
```

Containing this graph

```
title       "JVM Thread Count"
timezone    "Europe/London"
vtitle      "size"
linewidth   2
linemode    "staircase"
description "Threads Active"
ymin        0

servers = @properties[:servers] 
environment = @properties[:environment]
javaid = @properties[:javaid]

servers.each do |servername|
  serverid = servername.split('_')[0][-4..-1]

  field "threads_#{servername}".to_sym,
                 :alias => "#{serverid}",
                 :data  => "keepLastValue(servers.java.#{javaid}.#{environment}.#{servername}.jvm-threading.ThreadCount)"
end
```

We can override the servers and the timezone using this url:

http://localhost:3000/liveb/0_app_core/?p[servers][]=other_server.example.com&p[servers][]=other_server.example.com&p[timezone]=CET

Also, having this feature, we open the doors to the "dynamic dashboards" that I commented in other place. We can add this configuration in the dash.yaml:

```
:dynamic_properties:
  :server: 
    :type: "input"
    :default: "server1.example.net"
  :operations:
    :type: "multiselect"
    :values: [ "delete", "create", "update" ]
    :default: [ "update" ]
```

And that will generate a small form that allows compose a customized url with the needed placeholders
