### PR TITLE
Fix NoMethodError when graph_columns is set to 1

### DIFF
--- a/lib/gdash/monkey_patches.rb
+++ b/lib/gdash/monkey_patches.rb
@@ -4,7 +4,7 @@ class Array
       if block_given?
         self.each{|a| yield([a])}
       else
-        self
+        self.collect{|a| [a]}
       end
     else
       arr = self.clone


### PR DESCRIPTION
Setting `:graph_columns:` to 1 in gdash.yaml caused a `NoMethodError` to
be thrown when viewing a dashboard. The problem is that the monkey
patched `Array#in_groups_of` method returns the unmodified array when
called as `array.in_group_of(1)`, while clients are expecting to get an
array of 1 element arrays.
