### PR TITLE
Eliminate in_groups_of

### DIFF
--- a/lib/gdash/monkey_patches.rb
+++ b/lib/gdash/monkey_patches.rb
@@ -1,37 +1,3 @@
-class Array
-  def in_groups_of(chunk_size, padded_with=nil)
-    if chunk_size <= 1
-      if block_given?
-        self.each{|a| yield([a])}
-      else
-        self
-      end
-    else
-      arr = self.clone
-
-      # how many to add
-      padding = chunk_size - (arr.size % chunk_size)
-      padding = 0 if padding == chunk_size
-
-      # pad at the end
-      arr.concat([padded_with] * padding)
-
-      # how many chunks we'll make
-      count = arr.size / chunk_size
-
-      # make that many arrays
-      result = []
-      count.times {|s| result <<  arr[s * chunk_size, chunk_size]}
-
-      if block_given?
-        result.each{|a| yield(a)}
-      else
-        result
-      end
-    end
-  end
-end
-
 class GraphiteGraph
   attr_accessor :properties, :file
 end

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -135,6 +135,7 @@ class GDash
       else
         @error = "No dashboard called #{params[:dash]} found in #{params[:category]}/#{@top_level[params[:category]].list.join ','}"
       end
+      options.merge!(query_params)
 
       @graphs = @dashboard.graphs(options)
 

--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -6,19 +6,20 @@
    <h2><%= @error %></h2>
 <% else %>
 <body bgcolor="black">
-<table width="100%" height="100%">
-    <% @graphs.in_groups_of(params["columns"]) do |graphs| %>
-        <tr>
-        <% graphs.each do |graph| %>
-            <td valign="middle" align="center">
-            <% if graph %>
-                <img src='<%= [@dashboard.graphite_render, graph[:graphite][:url]].join "?" %>'>
-            <% end %>
-            </td>
-        <% end %>
-        </tr>
-    <% end %>
-</table>
+<% span=12/@graph_columns %>
+<div class="row">
+<% @graphs.each_with_index do |graph,i| %>
+  <% if graph %>
+    <% if i>0 and i%@graph_columns==0 %>
+       </div>
+       <div class="row">
+    <%end%>
+        <div align=center class="span<%=span%>" >
+        <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
+        </div>
+  <% end %>
+<% end %>
+</div>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -15,20 +15,20 @@ setTimeout("window.close();",1000);
 <% else %>
 <body bgcolor="white">
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
-
-<table width="100%" height="100%">
-    <% @graphs.in_groups_of(@graph_columns) do |graphrows| %>
-        <tr>
-        <% graphrows.each do |graph| %>
-            <td valign="middle" align="center">
-            <% if graph %>
-                <img src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>'>
-            <% end %>
-            </td>
-        <% end %>
-        </tr>
-    <% end %>
-</table>
+<% span=12/@graph_columns %>
+<div align=center class="row">
+<% @graphs.each_with_index do |graph,i| %>
+  <% if graph %>
+    <% if i>0 and i%@graph_columns==0 %>
+       </div>
+       <div align=center class="row">
+    <%end%>
+        <div class="span<%=span%>" >
+        <%= erb(:graph, :locals => { :graph => graph}) %>
+        </div>
+  <% end %>
+<% end %>
+</div>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -3,7 +3,6 @@
     <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
     <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
     <script language=Javascript>
-<link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
 window.print();
 ClosePrint();
 function ClosePrint( )

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -1,7 +1,9 @@
 <html>
 <head>
+    <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
     <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
     <script language=Javascript>
+<link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
 window.print();
 ClosePrint();
 function ClosePrint( )
@@ -16,12 +18,12 @@ setTimeout("window.close();",1000);
 <body bgcolor="white">
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<div align=center class="row">
+<div class="row">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
        </div>
-       <div align=center class="row">
+       <div class="row">
     <%end%>
         <div class="span<%=span%>" >
         <%= erb(:graph, :locals => { :graph => graph}) %>

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -15,22 +15,19 @@ setTimeout("window.close();",1000);
    <h2><%= @error %></h2>
 <% else %>
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<% span=12/@graph_columns %>
 <div class="row">
-    <table>
-        <% row = 1 %>
-        <% @graphs.in_groups_of(@graph_columns) do |graphrows| %>
-          <tr>
-          <% graphrows.each do |graph| %>
-            <td>
-            <% if graph %>
-              <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-            <% end %>
-            </td>
-          <% end %>
-	  </tr>
-          <% row += 1 %>
-        <% end %>
-    </table>
+<% @graphs.each_with_index do |graph,i| %>
+  <% if graph %>
+    <% if i>0 and i%@graph_columns==0 %>
+       </div>
+       <div class="row">
+    <%end%>
+        <div align=center class="span<%=span%>" >
+          <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
+        </div>
+  <% end %>
+<% end %>
 </div>
 <% end %>
 </body>

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -1,7 +1,10 @@
 <html>
 <head>
+    <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
     <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
     <script language=Javascript>
+<link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
+
 window.print();
 ClosePrint();
 function ClosePrint( )
@@ -23,7 +26,7 @@ setTimeout("window.close();",1000);
        </div>
        <div class="row">
     <%end%>
-        <div align=center class="span<%=span%>" >
+        <div class="span<%=span%>" >
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
         </div>
   <% end %>

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -3,8 +3,6 @@
     <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
     <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
     <script language=Javascript>
-<link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
-
 window.print();
 ClosePrint();
 function ClosePrint( )


### PR DESCRIPTION
With this commit we eliminate all uses of in_groups_of, after @keymon astutely observed that it had already been removed from the normal dashboard views but is still present in print and full views. The in_groups_of function is now removed from monkey_patches. 
