### PR TITLE
convert to bootstrap thumbnails rather than rows when displaying images

### DIFF
--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -117,7 +117,7 @@ class GDash
       options = {}
       params["splat"] = params["splat"].first.split("/")
 
-      params["columns"] = params["splat"][0].to_i || @graph_columns
+      @graph_columns = params["splat"][0].to_i unless params["splat"][0].nil?
 
       if params["splat"].size == 3
         options[:width] = params["splat"][1].to_i

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,21 +1,27 @@
 <% unless @error %>
-<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
-<%= erb :_interval_filter, :layout => false unless @interval_filters.empty? %>
-<div class="row" style="text-align: right"><small>Source: <a class="muted" href="<%=@dashboard.graphite_render.sub("/render","")%>"><%=@dashboard.graphite_render.sub("/render","")%></a></small></h2></div>
-<% span=12/@graph_columns %>
 <div class="row">
+  <div class="span6">
+   <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+  </div>
+  <div class="span6" align=right>
+    <small>Source: <a class="muted" href="<%=@dashboard.graphite_render.sub("/render","")%>"><%=@dashboard.graphite_render.sub("/render","")%></a></small>
+  </div>
+</div>
+<%= erb :_interval_filter, :layout => false unless @interval_filters.empty? %>
+<% span=12/@graph_columns %>
+<ul class="thumbnails">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </div>
-       <div class="row">
+       </ul>
+       <ul class="thumbnails">
     <%end%>
-        <div class="span<%=span%>" >
+        <li class="span<%=span%>">
         <%= erb(:graph, :locals => { :graph => graph }) %>
-        </div>
+        </li>
   <% end %>
 <% end %>
-</div>
+</ul>
 <script>
     $(function () {
       $(".graph img")

--- a/views/detailed_dashboard.erb
+++ b/views/detailed_dashboard.erb
@@ -1,19 +1,19 @@
 <% unless @error %>
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<div class="row">
+<ul class="thumbnails">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </div>
-       <div class="row">
+       </ul>
+       <ul class="thumbnails">
     <%end%>
-        <div class="span<%=span%>" >
+        <li class="span<%=span%>" >
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-        </div>
+        </li>
   <% end %>
 <% end %>
-</div>
+</ul>
 <script>
     $(function () {
       $(".graph img")

--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -9,12 +9,12 @@
 <body style='background: black'>
 <div class="container">
   <% span=12/@graph_columns %>
-  <div class="row">
+<ul class="thumbnails">
   <% @graphs.each_with_index do |graph,i| %>
     <% if graph %>
       <% if i>0 and i%@graph_columns==0 %>
-         </div>
-         <div class="row">
+         </ul>
+         <ul class="thumbnails">
       <%end%>
           <div class="span<%=span%>" >
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
@@ -22,7 +22,7 @@
     <% end %>
   <% end %>
   </div>
-</div>
+</ul>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -1,24 +1,27 @@
 <html>
 <head>
     <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
 </head>
 <% if @error %>
    <h2><%= @error %></h2>
 <% else %>
-<body bgcolor="black">
-<% span=12/@graph_columns %>
-<div class="row">
-<% @graphs.each_with_index do |graph,i| %>
-  <% if graph %>
-    <% if i>0 and i%@graph_columns==0 %>
-       </div>
-       <div class="row">
-    <%end%>
-        <div align=center class="span<%=span%>" >
-        <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-        </div>
+<body style='background: black'>
+<div class="container">
+  <% span=12/@graph_columns %>
+  <div class="row">
+  <% @graphs.each_with_index do |graph,i| %>
+    <% if graph %>
+      <% if i>0 and i%@graph_columns==0 %>
+         </div>
+         <div class="row">
+      <%end%>
+          <div class="span<%=span%>" >
+          <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
+          </div>
+    <% end %>
   <% end %>
-<% end %>
+  </div>
 </div>
 <script>
     $(document).ready(function() {

--- a/views/graph.erb
+++ b/views/graph.erb
@@ -3,7 +3,7 @@
   <%qp=""; params['p'].each {|k,v| qp+="?p[#{k}]=#{v}"} unless params['p'].nil?%>
   <a href='<%= [@prefix, params[:category], @params[:dash], 'details', graph[:name], qp].join "/" %>'>
 <% end %>
-<img style="margin: 0 auto;" class="thumbnail" src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>' title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
+<img style="margin: 0 auto;" src='<%= [@top_level[@params[:category]].graphite_render, graph[:graphite][:url]].join "?" %>' title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
 <% unless omit_link %>
   </a>
 <% end %>

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -17,19 +17,19 @@ setTimeout("window.close();",1000);
 <body bgcolor="white">
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<div class="row">
+<ul class="thumbnails">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </div>
-       <div class="row">
+       </ul>
+       <ul class="thumbnails">
     <%end%>
-        <div class="span<%=span%>" >
+        <li class="span<%=span%>" >
         <%= erb(:graph, :locals => { :graph => graph}) %>
-        </div>
+        </li>
   <% end %>
 <% end %>
-</div>
+</ul>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -17,19 +17,19 @@ setTimeout("window.close();",1000);
 <% else %>
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<div class="row">
+<ul class="thumbnails">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </div>
-       <div class="row">
+       </ul>
+       <ul class="thumbnails">
     <%end%>
-        <div class="span<%=span%>" >
+        <li class="span<%=span%>" >
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-        </div>
+        </li>
   <% end %>
 <% end %>
-</div>
+</ul>
 <% end %>
 </body>
 </html>


### PR DESCRIPTION
This PR fixes issue #85. It also switches from using Bootstrap rows to strictly thumbnails, which I think it more appropriate for an image grid. Anyone care to review this?
