### PR TITLE
Revert to table so as not to constrain graph size

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     less (2.2.1)
       commonjs (~> 0.2.6)
     libv8 (3.3.10.4)
-    rack (1.4.1)
+    rack (1.4.5)
     rack-protection (1.2.0)
       rack
     redcarpet (2.1.1)

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,27 +1,41 @@
 <% unless @error %>
-<div class="row">
+
+<div class="row-fluid">
+  <div class="span2">
+  </div>
   <div class="span6">
    <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
   </div>
-  <div class="span6" align=right>
+  <div class="span4">
     <small>Source: <a class="muted" href="<%=@dashboard.graphite_render.sub("/render","")%>"><%=@dashboard.graphite_render.sub("/render","")%></a></small>
   </div>
 </div>
+<div class="row-fluid">
+  <div class="span2">
+  </div>
+  <div class="span8">
 <%= erb :_interval_filter, :layout => false unless @interval_filters.empty? %>
+  </div>
+  <div class="span2">
+  </div>
+</div>
+<table align=center>
+<tr>
 <% span=12/@graph_columns %>
-<ul class="thumbnails">
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </ul>
-       <ul class="thumbnails">
+      </tr>
+<tr>
     <%end%>
-        <li class="span<%=span%>">
+<td>
         <%= erb(:graph, :locals => { :graph => graph }) %>
-        </li>
+</td>
   <% end %>
 <% end %>
-</ul>
+</tr>
+</table>
+
 <script>
     $(function () {
       $(".graph img")

--- a/views/detailed_dashboard.erb
+++ b/views/detailed_dashboard.erb
@@ -1,19 +1,28 @@
 <% unless @error %>
+<div class="row-fluid">
+  <div class="span2">
+  </div>
+  <div class="span6">
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+  </div>
+</div>
+  
 <% span=12/@graph_columns %>
-<ul class="thumbnails">
+<table align=center>
+<tr>
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </ul>
-       <ul class="thumbnails">
+       </tr>
+       <tr>
     <%end%>
-        <li class="span<%=span%>" >
+        <td>
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-        </li>
+        </td>
   <% end %>
 <% end %>
-</ul>
+</tr>
+</table>
 <script>
     $(function () {
       $(".graph img")

--- a/views/full_size_dashboard.erb
+++ b/views/full_size_dashboard.erb
@@ -9,20 +9,21 @@
 <body style='background: black'>
 <div class="container">
   <% span=12/@graph_columns %>
-<ul class="thumbnails">
+<table>
+<tr>
   <% @graphs.each_with_index do |graph,i| %>
     <% if graph %>
       <% if i>0 and i%@graph_columns==0 %>
-         </ul>
-         <ul class="thumbnails">
+         </tr>
+         <tr>
       <%end%>
-          <div class="span<%=span%>" >
+          <td>
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-          </div>
+          </td>
     <% end %>
   <% end %>
-  </div>
-</ul>
+</tr>
+</table>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/graph.erb
+++ b/views/graph.erb
@@ -1,9 +1,9 @@
 <% omit_link ||= false %>
 <% unless omit_link %>
-  <%qp=""; params['p'].each {|k,v| qp+="?p[#{k}]=#{v}"} unless params['p'].nil?%>
+  <%qp="?#{request.env['rack.request.query_string']}" %>
   <a href='<%= [@prefix, params[:category], @params[:dash], 'details', graph[:name], qp].join "/" %>'>
 <% end %>
-<img style="margin: 0 auto;" src='<%= [@dashboard.graphite_render, graph[:graphite][:url]].join "?" %>' title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
+<img style="margin: 0 auto;" src='<%= [@dashboard.graphite_render, graph[:graphite][:url]].join "?" %>' title="<%= graph[:graphite][:title] %>" data-content="<%= graph[:graphite][:description] %>">
 <% unless omit_link %>
   </a>
 <% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,7 +22,7 @@
     <body>
         <div class="navbar">
                 <div class="navbar-inner">
-                    <div class="container">
+                    <div class="container-fluid">
                         <a class="brand" href="<%= @prefix %>/"><%= @dash_title %></a>
                         <ul class="nav">
                         <% @top_level.keys.sort.each do |category| %>
@@ -64,7 +64,7 @@
             </div>
         </div>
 
-        <div class="container">
+        <div class="container-fluid">
                 <% if @error %>
                 <div class="alert alert-error alert-block">
                   <button type="button" class="close" data-dismiss="alert">&times;</button>

--- a/views/print_dashboard.erb
+++ b/views/print_dashboard.erb
@@ -17,19 +17,21 @@ setTimeout("window.close();",1000);
 <body bgcolor="white">
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<ul class="thumbnails">
+<table>
+<tr>
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </ul>
-       <ul class="thumbnails">
+       </tr>
+       <tr>
     <%end%>
-        <li class="span<%=span%>" >
+        <td>
         <%= erb(:graph, :locals => { :graph => graph}) %>
-        </li>
+        </td>
   <% end %>
 <% end %>
-</ul>
+</tr>
+</table>
 <script>
     $(document).ready(function() {
         setInterval(reloadDash, <%= @refresh_rate * 1000 %>);

--- a/views/print_detailed_dashboard.erb
+++ b/views/print_detailed_dashboard.erb
@@ -17,19 +17,21 @@ setTimeout("window.close();",1000);
 <% else %>
 <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
 <% span=12/@graph_columns %>
-<ul class="thumbnails">
+<table>
+<tr>
 <% @graphs.each_with_index do |graph,i| %>
   <% if graph %>
     <% if i>0 and i%@graph_columns==0 %>
-       </ul>
-       <ul class="thumbnails">
+       </tr>
+       <tr>
     <%end%>
-        <li class="span<%=span%>" >
+        <td>
           <%= erb(:graph, :locals => { :graph => graph, :omit_link => true }) %>
-        </li>
+        </td>
   <% end %>
 <% end %>
-</ul>
+</tr>
+</table>
 <% end %>
 </body>
 </html>


### PR DESCRIPTION
Per issue #93 and #86. This reverts the change to thumbnails since the span restricts the image size. This also sets the container to fluid so as to be better supported on a variety of displays.
