### PR TITLE
Dash description reformat

### DIFF
--- a/views/_dash_header.erb
+++ b/views/_dash_header.erb
@@ -1,5 +1,6 @@
 <div class="span2">
 </div>
 <div class="span6">
-<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+<h1><%= @dashboard.name %></h1>
+<h2><small><%= @dashboard.description %></small></h2>
 </div>

--- a/views/_dash_header.erb
+++ b/views/_dash_header.erb
@@ -1,0 +1,5 @@
+<div class="span2">
+</div>
+<div class="span6">
+<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
+</div>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,11 +1,7 @@
 <% unless @error %>
 
 <div class="row-fluid">
-  <div class="span2">
-  </div>
-  <div class="span6">
-   <h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
-  </div>
+  <%= erb :_dash_header %>
   <div class="span4">
     <small>Source: <a class="muted" href="<%=@dashboard.graphite_render.sub("/render","")%>"><%=@dashboard.graphite_render.sub("/render","")%></a></small>
   </div>

--- a/views/detailed_dashboard.erb
+++ b/views/detailed_dashboard.erb
@@ -1,10 +1,6 @@
 <% unless @error %>
 <div class="row-fluid">
-  <div class="span2">
-  </div>
-  <div class="span6">
-<h1><%= @dashboard.name %>&nbsp;<small><%= @dashboard.description %></small></h1>
-  </div>
+  <%= erb :_dash_header %>
 </div>
   
 <% span=12/@graph_columns %>


### PR DESCRIPTION
Nontrivial (as in, larger than a word or two, though still single-sentence) dashboard descriptions format poorly in the current layout, which just nests a `<small>` within the `<h1>`.

Moving the description to its own `<h2>` looks much better and doesn't appear to sacrifice anything obvious, re: style/layout.

Took opportunity to do a tiny refactor while fixing this :) DRY FTW.
