### PR TITLE
make link to jquery-ui.css protocol relative

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,7 @@
     <head>
         <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
         <link rel="stylesheet" type="text/css" href="<%= @prefix %>/bootstrap/bootstrap.css">
-        <link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.10.0/themes/smoothness/jquery-ui.css">
+        <link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.10.0/themes/smoothness/jquery-ui.css">
         <link rel="stylesheet" type="text/css" href="<%= @prefix %>/js/jquery-ui-timepicker-addon.css">
         <script src="<%= @prefix %>/js/jquery-1.7.2.min.js"></script>
         <script src="<%= @prefix %>/js/jquery-ui-1.10.0.custom.min.js"></script>


### PR DESCRIPTION
When serving out gdash over https, some browsers (eg the latest version of Firefox) block the link to jquery-ui.css since its href is specifically pointing to a http URL. Changed the href to a protocol relative URL. 
