### PR TITLE
Export json for all templates that contains warning or critical

### DIFF
--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -107,6 +107,7 @@ class GDash
       end
       return_data.to_json
     end
+
     get '/search?*' do
       search_string = params['dashboard'] || '' 
       d1,d2 = search_string.split('/', 2)

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -87,6 +87,24 @@ class GDash
       erb :index
     end
 
+    get '/monitoring_export' do
+      content_type :json
+      return_data = []
+      @top_level.keys.each do |category|
+        @top_level[category].dashboards.each do |dashboard_name|
+          Dashboard.new(dashboard_name[:link], @graph_templates, dashboard_name[:category], {}, @graphite_render).graphs.each do |graph|
+            graph_object = graph[:graphite]
+            if graph[:graphite].warning_threshold.any? and graph[:graphite].critical_threshold.any?
+              return_data << {
+                :graphite_url => [@graphite_render, "?", graph[:graphite].url].join,
+                :graph_properties => graph[:graphite].properties
+              }
+            end
+          end
+        end
+      end
+      return_data.to_json
+    end
     get '/search?*' do
       search_string = params['dashboard'] || '' 
       d1,d2 = search_string.split('/', 2)

--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -94,10 +94,12 @@ class GDash
         @top_level[category].dashboards.each do |dashboard_name|
           Dashboard.new(dashboard_name[:link], @graph_templates, dashboard_name[:category], {}, @graphite_render).graphs.each do |graph|
             graph_object = graph[:graphite]
-            if graph[:graphite].warning_threshold.any? and graph[:graphite].critical_threshold.any?
+            if graph_object.warning_threshold.any? or graph_object.critical_threshold.any?
               return_data << {
-                :graphite_url => [@graphite_render, "?", graph[:graphite].url].join,
-                :graph_properties => graph[:graphite].properties
+                :graphite_url => [@graphite_render, "?", graph_object.url].join,
+                :warning => graph_object.warning_threshold,
+                :critical => graph_object.critical_threshold,
+                :graph_properties => graph_object.properties
               }
             end
           end


### PR DESCRIPTION
Given a template like 

```
title "Beanstalkd default Tube Reserved Jobs in #{environment}"
timezone "Europe/London"
vtitle "count"
linewidth 2
linemode "connected"
description "Beanstalkd default tube stats for #{environment}"
ymin 0

servers = @properties[:servers]
environment = @properties[:environment]

warning :value => 1000
critical :value => 2000

field "current_jobs_reserved".to_sym,
        :alias => "Current Jobs Reserved",
        :data => "servers.#{servers[0]}.beanstalkd.counter-default-current-jobs-reserved.value"
```

The new endpoint returns a list of dicts like so

```
[ { "critical" : [ 2000 ],
    "graph_properties" : { "app_environment" : "qa1",
        "area" : "none",
        "area_alpha" : null,
        "background_color" : "black",
        "description" : "Beanstalkd default tube buried jobs for ",
        "draw_null_as_zero" : false,
        "environment" : "qa1",
        "fontbold" : false,
        "fontname" : null,
        "fontsize" : null,
        "foreground_color" : "white",
        "from" : "-1hour",
        "height" : 250,
        "hide_grid" : null,
        "hide_legend" : false,
        "javaid" : "beanstalkd",
        "linemode" : "connected",
        "linewidth" : 2,
        "logbase" : null,
        "major_grid_line_color" : null,
        "minor_grid_line_color" : null,
        "placeholders" : null,
        "servers" : [ "server" ],
        "surpress" : false,
        "timezone" : "Europe/London",
        "title" : "Beanstalkd default Tube buried jobs in ",
        "until" : "now",
        "vertical_mark_color" : "#330000",
        "virtual_server_identifier" : "vs-core_qa1_springer_com_80",
        "vtitle" : "count",
        "vtitle_right" : null,
        "width" : 500,
        "xformat" : null,
        "ymax" : null,
        "ymaxright" : null,
        "ymin" : 0,
        "yminright" : null,
        "yunit_system" : null
      },
    "graphite_url" : "http://graphite-url.com/render/?title=Beanstalkd+default+Tube+buried+jobs+in+&vtitle=count&from=-1hour&width=500&height=250&until=now&areaMode=none&hideLegend=false&yMin=0&lineWidth=2&lineMode=connected&tz=Europe%2FLondon&bgcolor=black&fgcolor=white&target=alias%28dashed%28color%28threshold%281000%29%2C%22orange%22%29%29%2C%22warn_0%22%29&target=alias%28dashed%28color%28threshold%282000%29%2C%22red%22%29%29%2C%22crit_0%22%29&target=alias%server.beanstalkd.counter-default-current-jobs-buried.value%2C%22Current+Jobs+Buried%22%29",
    "warning" : [ 1000 ]
  }, .....]
```

Useful for generating nagios checks(for example) for all graphs that contains warning/critical 
