### PR TITLE
When using the Custom Date Picker make sure that the URL parameters are passed to the newUrl

### DIFF
--- a/lib/gdash/sinatra_app.rb
+++ b/lib/gdash/sinatra_app.rb
@@ -124,7 +124,7 @@ class GDash
         end
       end
   
-      result = mapper.select {|d| d[:name] == dashboard && (category == nil || d[:category] == category )}
+      result = mapper.select {|d| d[:name].include?(dashboard) && (category == nil || d[:category] == category )}
 
       if result.count == 1
         redirect "#{@prefix}/#{result[0][:category]}/#{result[0][:link]}"

--- a/public/js/selectdate.js
+++ b/public/js/selectdate.js
@@ -57,11 +57,12 @@ function formatSelectedDate(date) {
 function selectDt() {
   dt_from = $('#dt_from').datetimepicker('getDate');
   dt_to = $('#dt_to').datetimepicker('getDate');
-  window.location = buildGraphiteDateUrl(dt_from, dt_to);
+  var queryString = location.search;
+  window.location = buildGraphiteDateUrl(dt_from, dt_to, queryString);
   return true;
 }
 
-function buildGraphiteDateUrl(dt_from, dt_to)
+function buildGraphiteDateUrl(dt_from, dt_to, queryString)
 {
   from = buildGraphiteDateString(dt_from);
   to = buildGraphiteDateString(dt_to);
@@ -71,7 +72,11 @@ function buildGraphiteDateUrl(dt_from, dt_to)
   if (newurl.match(regex)) {
     newurl = newurl.replace(regex,"");
   }
-  return newurl + params;
+  if (queryString) {
+    return newurl + params + "/" + queryString;
+  } else {
+    return newurl + params;
+  }
 }
 
 function buildGraphiteDateString(date)


### PR DESCRIPTION
I use the "?p[server]=servername" a lot for my dynamic dashboards, when using the "Select Date" custom date picker the URL args are stripped off from the new url that is generated with the custom time range.

This patch fixes it and copy on the new URL any custom arg passed on the original url
